### PR TITLE
Add descriptor safelist export API

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,29 @@ This is enabled by the **incremental source generator** (`TailwindVariants.Sourc
 
 ---
 
+
+## Safelist Export
+
+You can export descriptor-declared Tailwind tokens for Tailwind content scanning:
+
+```csharp
+using TailwindVariants.NET.Export;
+
+var tokens = TvSafelistExporter.GetTokens(
+    Button.Descriptor,
+    Alert.Descriptor);
+
+var safelist = TvSafelistExporter.GetString(
+    Button.Descriptor,
+    Alert.Descriptor);
+
+await File.WriteAllTextAsync("tailwindvariants.safelist.txt", safelist);
+```
+
+The exporter reads statically declared class strings from descriptors, always deduplicates tokens, and sorts tokens by default for deterministic output. It does not run TailwindMerge and does not serialize descriptors.
+
+---
+
 ## Documentation
 
 Go to the [documentation](http://tailwindvariants-net-docs.denny093.dev/) for the full explanation of the example

--- a/src/TailwindVariants.NET/Core/TvDescriptor.cs
+++ b/src/TailwindVariants.NET/Core/TvDescriptor.cs
@@ -1,3 +1,4 @@
+using TailwindVariants.NET.Export;
 using TailwindVariants.NET.Models;
 
 using static TailwindVariants.NET.TvHelpers;
@@ -36,7 +37,7 @@ public interface ITvDescriptor
 /// </summary>
 /// <typeparam name="TOwner">The type that owns the slots and variants.</typeparam>
 /// <typeparam name="TSlots">The type representing the slots, which must implement <see cref="ISlots"/>.</typeparam>
-public sealed class TvDescriptor<TOwner, TSlots> : ITvDescriptor
+public sealed class TvDescriptor<TOwner, TSlots> : ITvDescriptor, ITvSafelistSource
 	where TSlots : ISlots, new()
 	where TOwner : ISlottable<TSlots>
 {
@@ -113,6 +114,64 @@ public sealed class TvDescriptor<TOwner, TSlots> : ITvDescriptor
 	/// This collection is populated during initialization by compiling variant expressions and merging with extended variants.
 	/// </summary>
 	IReadOnlyCollection<ICompiledVariant>? ITvDescriptor.Variants => _variants;
+
+
+	IEnumerable<string?> ITvSafelistSource.GetSafelistClassStrings()
+	{
+		if (Base is not null)
+		{
+			yield return Base.ToString();
+		}
+
+		if (Slots is not null)
+		{
+			foreach (var (_, classValue) in Slots)
+			{
+				yield return classValue.ToString();
+			}
+		}
+
+		if (Variants is not null)
+		{
+			foreach (var (_, variant) in Variants)
+			{
+				if (variant is not System.Collections.IEnumerable enumerableVariant)
+				{
+					continue;
+				}
+
+				foreach (var item in enumerableVariant)
+				{
+					var valueProperty = item?.GetType().GetProperty("Value");
+					if (valueProperty?.GetValue(item) is not SlotCollection<TSlots> slotClasses)
+					{
+						continue;
+					}
+
+					foreach (var (_, classValue) in slotClasses)
+					{
+						yield return classValue.ToString();
+					}
+				}
+			}
+		}
+
+		if (CompoundVariants is not null)
+		{
+			foreach (var compound in CompoundVariants)
+			{
+				if (compound.Class is not null)
+				{
+					yield return compound.Class;
+				}
+
+				foreach (var (_, classValue) in compound)
+				{
+					yield return classValue.ToString();
+				}
+			}
+		}
+	}
 
 	#endregion Explicit Implementations
 

--- a/src/TailwindVariants.NET/Export/ITvSafelistSource.cs
+++ b/src/TailwindVariants.NET/Export/ITvSafelistSource.cs
@@ -1,0 +1,20 @@
+namespace TailwindVariants.NET.Export;
+
+/// <summary>
+/// Exposes raw descriptor-declared class strings that can be tokenized for Tailwind safelist generation.
+/// </summary>
+/// <remarks>
+/// Implementations should return statically declared class strings from descriptor configuration,
+/// not runtime-resolved, merged, or state-dependent output. Null, empty, and whitespace-only values
+/// are allowed and are ignored by <see cref="TvSafelistExporter"/>.
+/// </remarks>
+public interface ITvSafelistSource
+{
+	/// <summary>
+	/// Gets the raw class strings declared by this source for safelist token extraction.
+	/// </summary>
+	/// <returns>
+	/// A sequence of raw class strings declared by the source. Items may be null or whitespace-only.
+	/// </returns>
+	IEnumerable<string?> GetSafelistClassStrings();
+}

--- a/src/TailwindVariants.NET/Export/TvClassTokenParser.cs
+++ b/src/TailwindVariants.NET/Export/TvClassTokenParser.cs
@@ -1,0 +1,20 @@
+namespace TailwindVariants.NET.Export;
+
+internal static class TvClassTokenParser
+{
+	public static IEnumerable<string> Parse(string? classString)
+	{
+		if (string.IsNullOrWhiteSpace(classString))
+		{
+			yield break;
+		}
+
+		foreach (var token in classString.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+		{
+			if (!string.IsNullOrWhiteSpace(token))
+			{
+				yield return token;
+			}
+		}
+	}
+}

--- a/src/TailwindVariants.NET/Export/TvSafelistExportOptions.cs
+++ b/src/TailwindVariants.NET/Export/TvSafelistExportOptions.cs
@@ -1,0 +1,30 @@
+namespace TailwindVariants.NET.Export;
+
+/// <summary>
+/// Controls deterministic ordering and token comparison behavior used by <see cref="TvSafelistExporter"/>.
+/// </summary>
+/// <remarks>
+/// Exported tokens are always deduplicated. The configured comparer is used for uniqueness checks
+/// and, when enabled, deterministic sorting.
+/// </remarks>
+public sealed class TvSafelistExportOptions
+{
+	/// <summary>
+	/// Gets the standard exporter behavior: ordinal comparison with sorted unique output.
+	/// </summary>
+	public static TvSafelistExportOptions Default { get; } = new();
+
+	/// <summary>
+	/// Gets a value indicating whether unique tokens are sorted for deterministic output and cleaner generated files.
+	/// </summary>
+	public bool SortTokens { get; init; } = true;
+
+	/// <summary>
+	/// Gets the comparer used for both deduplication and optional sorting.
+	/// </summary>
+	/// <remarks>
+	/// The default is <see cref="StringComparer.Ordinal"/> because Tailwind class tokens are treated
+	/// as case-sensitive literal strings.
+	/// </remarks>
+	public StringComparer Comparer { get; init; } = StringComparer.Ordinal;
+}

--- a/src/TailwindVariants.NET/Export/TvSafelistExporter.cs
+++ b/src/TailwindVariants.NET/Export/TvSafelistExporter.cs
@@ -1,0 +1,79 @@
+namespace TailwindVariants.NET.Export;
+
+/// <summary>
+/// Exports Tailwind safelist tokens from descriptor sources.
+/// </summary>
+/// <remarks>
+/// The exporter reads statically declared class strings and splits them into whitespace-separated tokens.
+/// It does not evaluate predicates, inspect runtime owner state, or run TailwindMerge because safelist
+/// generation must preserve every declared token.
+/// </remarks>
+public static class TvSafelistExporter
+{
+	/// <summary>
+	/// Extracts unique Tailwind tokens from one or more safelist sources passed as a params array.
+	/// </summary>
+	/// <param name="sources">The descriptor sources to export.</param>
+	/// <returns>A deduplicated token array sorted using default options.</returns>
+	/// <exception cref="ArgumentNullException"><paramref name="sources"/> is null, or contains a null item.</exception>
+	public static string[] GetTokens(params ITvSafelistSource[] sources)
+		=> GetTokens((IEnumerable<ITvSafelistSource>)sources);
+
+	/// <summary>
+	/// Extracts unique Tailwind tokens from an enumerable of safelist sources.
+	/// </summary>
+	/// <param name="sources">The descriptor sources to export.</param>
+	/// <param name="options">Optional export settings. When null, <see cref="TvSafelistExportOptions.Default"/> is used.</param>
+	/// <returns>A deduplicated token array, optionally sorted using <paramref name="options"/>.</returns>
+	/// <exception cref="ArgumentNullException"><paramref name="sources"/> is null, or contains a null item.</exception>
+	public static string[] GetTokens(IEnumerable<ITvSafelistSource> sources, TvSafelistExportOptions? options = null)
+	{
+		ArgumentNullException.ThrowIfNull(sources);
+		options ??= TvSafelistExportOptions.Default;
+
+		var seen = new HashSet<string>(options.Comparer);
+		var tokens = new List<string>();
+
+		foreach (var source in sources)
+		{
+			ArgumentNullException.ThrowIfNull(source);
+
+			foreach (var classString in source.GetSafelistClassStrings())
+			{
+				foreach (var token in TvClassTokenParser.Parse(classString))
+				{
+					if (seen.Add(token))
+					{
+						tokens.Add(token);
+					}
+				}
+			}
+		}
+
+		if (options.SortTokens)
+		{
+			tokens.Sort(options.Comparer);
+		}
+
+		return [.. tokens];
+	}
+
+	/// <summary>
+	/// Exports unique Tailwind tokens from one or more safelist sources and joins them with single spaces.
+	/// </summary>
+	/// <param name="sources">The descriptor sources to export.</param>
+	/// <returns>A single space-delimited string of unique tokens.</returns>
+	/// <exception cref="ArgumentNullException"><paramref name="sources"/> is null, or contains a null item.</exception>
+	public static string GetString(params ITvSafelistSource[] sources)
+		=> GetString((IEnumerable<ITvSafelistSource>)sources);
+
+	/// <summary>
+	/// Exports unique Tailwind tokens from an enumerable of safelist sources and joins them with single spaces.
+	/// </summary>
+	/// <param name="sources">The descriptor sources to export.</param>
+	/// <param name="options">Optional export settings. When null, <see cref="TvSafelistExportOptions.Default"/> is used.</param>
+	/// <returns>A single space-delimited string of unique tokens.</returns>
+	/// <exception cref="ArgumentNullException"><paramref name="sources"/> is null, or contains a null item.</exception>
+	public static string GetString(IEnumerable<ITvSafelistSource> sources, TvSafelistExportOptions? options = null)
+		=> string.Join(" ", GetTokens(sources, options));
+}

--- a/tests/TailwindVariants.NET.Tests/Export/TvSafelistExporterTests.cs
+++ b/tests/TailwindVariants.NET.Tests/Export/TvSafelistExporterTests.cs
@@ -1,0 +1,275 @@
+using TailwindVariants.NET.Export;
+
+namespace TailwindVariants.NET.Tests.Export;
+
+public sealed class TvSafelistExporterTests
+{
+	[Fact]
+	public void GetTokens_ExportsBaseVariantAndCompoundVariantTokens()
+	{
+		var tokens = TvSafelistExporter.GetTokens(SafelistTestButton.Descriptor);
+
+		var expected = new[]
+		{
+			"font-semibold",
+			"border",
+			"rounded",
+			"bg-blue-500",
+			"text-white",
+			"border-transparent",
+			"bg-white",
+			"text-gray-800",
+			"border-gray-400",
+			"text-sm",
+			"py-1",
+			"px-2",
+			"text-base",
+			"py-2",
+			"px-4",
+			"hover:bg-blue-600"
+		}
+		.Distinct(StringComparer.Ordinal)
+		.OrderBy(x => x, StringComparer.Ordinal)
+		.ToArray();
+
+		Assert.Equal(expected, tokens);
+	}
+
+	[Fact]
+	public void GetTokens_AlwaysDeduplicatesTokens()
+	{
+		var tokens = TvSafelistExporter.GetTokens(SafelistDuplicateTokenComponent.Descriptor);
+
+		Assert.Single(tokens.Where(t => t == "px-4"));
+		Assert.Single(tokens.Where(t => t == "text-sm"));
+	}
+
+	[Fact]
+	public void GetTokens_AcceptsMultipleDescriptors()
+	{
+		var tokens = TvSafelistExporter.GetTokens(
+			SafelistTestButton.Descriptor,
+			SafelistTestAlert.Descriptor);
+
+		Assert.Contains("bg-blue-500", tokens);
+		Assert.Contains("rounded-md", tokens);
+		Assert.Contains("border-red-500", tokens);
+		Assert.Contains("text-red-700", tokens);
+		Assert.Equal(tokens.Distinct(StringComparer.Ordinal).Count(), tokens.Length);
+	}
+
+	[Fact]
+	public void GetString_ReturnsSpaceSeparatedTokens()
+	{
+		var tokens = TvSafelistExporter.GetTokens(SafelistTestAlert.Descriptor);
+		var s = TvSafelistExporter.GetString(SafelistTestAlert.Descriptor);
+
+		Assert.Equal(string.Join(" ", tokens), s);
+		Assert.DoesNotContain("  ", s);
+		Assert.False(s.EndsWith(" ", StringComparison.Ordinal));
+	}
+
+	[Fact]
+	public void GetTokens_PreservesTailwindModifiersAndArbitraryValueTokens()
+	{
+		var tokens = TvSafelistExporter.GetTokens(SafelistArbitraryValueComponent.Descriptor);
+
+		Assert.Contains("hover:bg-blue-600", tokens);
+		Assert.Contains("md:hover:bg-blue-700", tokens);
+		Assert.Contains("dark:focus:ring-2", tokens);
+		Assert.Contains("data-[state=open]:animate-in", tokens);
+		Assert.Contains("[&>svg]:size-4", tokens);
+		Assert.Contains("grid-cols-[1fr_500px_2fr]", tokens);
+		Assert.Contains("bg-[oklch(0.7_0.15_240)]", tokens);
+	}
+
+	[Fact]
+	public void GetTokens_ThrowsForNullSourcesCollection()
+	{
+		IEnumerable<ITvSafelistSource>? src = null;
+
+		Assert.Throws<ArgumentNullException>(() =>
+			TvSafelistExporter.GetTokens(src!));
+	}
+
+	[Fact]
+	public void GetTokens_ThrowsForNullSourceInsideCollection()
+	{
+		ITvSafelistSource?[] src =
+		[
+			SafelistTestButton.Descriptor,
+			null
+		];
+
+		Assert.Throws<ArgumentNullException>(() =>
+			TvSafelistExporter.GetTokens(src!));
+	}
+
+	[Fact]
+	public void GetTokens_CanPreserveFirstSeenOrderWhenSortingIsDisabled()
+	{
+		var tokens = TvSafelistExporter.GetTokens(
+			[SafelistOrderedTokenComponent.Descriptor],
+			new TvSafelistExportOptions
+			{
+				SortTokens = false
+			});
+
+		Assert.Equal(["z-token", "a-token", "m-token"], tokens);
+	}
+
+	[Fact]
+	public void GetTokens_UsesConfiguredComparerForDeduplicationAndSorting()
+	{
+		var defaultTokens = TvSafelistExporter.GetTokens(SafelistCaseSensitiveComponent.Descriptor);
+
+		Assert.Contains("Token", defaultTokens);
+		Assert.Contains("token", defaultTokens);
+		Assert.Contains("TOKEN", defaultTokens);
+
+		var ignoreCase = TvSafelistExporter.GetTokens(
+			[SafelistCaseSensitiveComponent.Descriptor],
+			new TvSafelistExportOptions
+			{
+				SortTokens = false,
+				Comparer = StringComparer.OrdinalIgnoreCase
+			});
+
+		Assert.Equal(["Token"], ignoreCase);
+	}
+}
+
+public class SafelistTestButton : ISlottable<SafelistTestSlots>
+{
+	public static readonly TvDescriptor<SafelistTestButton, SafelistTestSlots> Descriptor = new(
+		@base: "font-semibold border rounded",
+		variants: new()
+		{
+			[b => b.Variant] = new Variant<ButtonVariant, SafelistTestSlots>
+			{
+				{ ButtonVariant.Primary, "bg-blue-500 text-white border-transparent" },
+				{ ButtonVariant.Secondary, "bg-white text-gray-800 border-gray-400" }
+			},
+			[b => b.Size] = new Variant<ButtonSize, SafelistTestSlots>
+			{
+				{ ButtonSize.Small, "text-sm py-1 px-2" },
+				{ ButtonSize.Medium, "text-base py-2 px-4" }
+			}
+		},
+		compoundVariants:
+		[
+			new(b => b.Variant == ButtonVariant.Primary && !b.Disabled)
+			{
+				Class = "hover:bg-blue-600"
+			}
+		]);
+
+	public string? Class { get; set; }
+
+	public SafelistTestSlots? Classes { get; set; }
+
+	public ButtonVariant Variant { get; set; }
+
+	public ButtonSize Size { get; set; }
+
+	public bool Disabled { get; set; }
+
+	public enum ButtonVariant
+	{
+		Primary,
+		Secondary
+	}
+
+	public enum ButtonSize
+	{
+		Small,
+		Medium
+	}
+}
+
+public class SafelistTestAlert : ISlottable<SafelistTestSlots>
+{
+	public static readonly TvDescriptor<SafelistTestAlert, SafelistTestSlots> Descriptor = new(
+		@base: "rounded-md border-red-500 text-red-700",
+		variants: new()
+		{
+			[a => a.Intent] = new Variant<AlertIntent, SafelistTestSlots>
+			{
+				{ AlertIntent.Danger, "bg-red-50" },
+				{ AlertIntent.Warning, "bg-yellow-50 text-yellow-800" }
+			}
+		});
+
+	public string? Class { get; set; }
+
+	public SafelistTestSlots? Classes { get; set; }
+
+	public AlertIntent Intent { get; set; }
+
+	public enum AlertIntent
+	{
+		Danger,
+		Warning
+	}
+}
+
+public class SafelistDuplicateTokenComponent : ISlottable<SafelistTestSlots>
+{
+	public static readonly TvDescriptor<SafelistDuplicateTokenComponent, SafelistTestSlots> Descriptor = new(
+		@base: "px-4 text-sm px-4",
+		variants: new()
+		{
+			[c => c.Size] = new Variant<SizeVariant, SafelistTestSlots>
+			{
+				{ SizeVariant.Small, "px-4 text-sm" },
+				{ SizeVariant.Medium, "px-4 text-sm" }
+			}
+		});
+
+	public string? Class { get; set; }
+
+	public SafelistTestSlots? Classes { get; set; }
+
+	public SizeVariant Size { get; set; }
+
+	public enum SizeVariant
+	{
+		Small,
+		Medium
+	}
+}
+
+public class SafelistArbitraryValueComponent : ISlottable<SafelistTestSlots>
+{
+	public static readonly TvDescriptor<SafelistArbitraryValueComponent, SafelistTestSlots> Descriptor = new(
+		@base: "hover:bg-blue-600 md:hover:bg-blue-700 dark:focus:ring-2 data-[state=open]:animate-in [&>svg]:size-4 grid-cols-[1fr_500px_2fr] bg-[oklch(0.7_0.15_240)]");
+
+	public string? Class { get; set; }
+
+	public SafelistTestSlots? Classes { get; set; }
+}
+
+public class SafelistOrderedTokenComponent : ISlottable<SafelistTestSlots>
+{
+	public static readonly TvDescriptor<SafelistOrderedTokenComponent, SafelistTestSlots> Descriptor = new(
+		@base: "z-token a-token m-token z-token");
+
+	public string? Class { get; set; }
+
+	public SafelistTestSlots? Classes { get; set; }
+}
+
+public class SafelistCaseSensitiveComponent : ISlottable<SafelistTestSlots>
+{
+	public static readonly TvDescriptor<SafelistCaseSensitiveComponent, SafelistTestSlots> Descriptor = new(
+		@base: "Token token TOKEN");
+
+	public string? Class { get; set; }
+
+	public SafelistTestSlots? Classes { get; set; }
+}
+
+public sealed partial class SafelistTestSlots : ISlots
+{
+	public string? Base { get; set; }
+}


### PR DESCRIPTION
## Summary

Adds a dedicated safelist export API under `TailwindVariants.NET.Export` for extracting all statically declared Tailwind class tokens from one or more `TvDescriptor` instances.

The end goal is to make it possible to generate Tailwind safelist strings by directly referencing the descriptors of specific components.

This feature is intentionally not descriptor serialization. It does not serialize lambdas, predicates, selectors, owner state, slot types, or runtime-resolved class output. Instead, it exposes the Tailwind tokens declared by descriptors so consuming applications and build tools can generate smaller, descriptor-specific safelist files for Tailwind scanning.

## Changes

- Added the `TailwindVariants.NET.Export` namespace.
- Added `ITvSafelistSource` as a non-generic abstraction for descriptor safelist export.
- Updated `TvDescriptor<TOwner, TSlots>` to expose its raw class strings through `ITvSafelistSource`.
- Added `TvSafelistExporter` with:
  - `GetTokens(params ITvSafelistSource[] sources)`
  - `GetTokens(IEnumerable<ITvSafelistSource> sources, TvSafelistExportOptions? options = null)`
  - `GetString(params ITvSafelistSource[] sources)`
  - `GetString(IEnumerable<ITvSafelistSource> sources, TvSafelistExportOptions? options = null)`
- Added `TvSafelistExportOptions` for controlling deterministic sorting and token comparison.
- Added internal token parsing for whitespace-separated Tailwind class strings.
- Added tests covering:
  - Base class token export
  - Variant token export
  - Compound variant token export
  - Duplicate token removal
  - Multiple descriptor export
  - Space-separated string export
  - Tailwind modifiers and arbitrary-value tokens
  - Null argument handling
  - First-seen order preservation when sorting is disabled
  - Custom comparer behavior
- Added useful XML documentation for all new public APIs.
- Added implementation comments for non-obvious safelist export behavior.

## Design Notes

Tokens are always deduplicated because duplicate entries provide no value in a Tailwind safelist.

Tokens are sorted by default using `StringComparer.Ordinal` to keep generated output deterministic and source-control friendly.

When `SortTokens` is disabled, the exporter preserves first-seen unique token order rather than relying on `HashSet` enumeration order.

The exporter does not run TailwindMerge. Safelist generation must preserve every descriptor-declared token, even when some tokens would conflict at runtime and be merged away for a specific component state.

Compound variant classes are exported without evaluating their predicates because the exporter is collecting every possible class token that a descriptor may emit, not the classes for a specific runtime state.

## Non-Goals

This PR does not add descriptor serialization or deserialization.
It does not add JSON export.
It does not add an export result object.
It does not change runtime rendering behavior.
It does not introduce JavaScript or Tailwind runtime dependencies.

## Example

```csharp
using TailwindVariants.NET.Export;

var tokens = TvSafelistExporter.GetTokens(
    Button.Descriptor,
    Alert.Descriptor,
    Card.Descriptor);

var safelist = TvSafelistExporter.GetString(
    Button.Descriptor,
    Alert.Descriptor,
    Card.Descriptor);

await File.WriteAllTextAsync("tailwindvariants.safelist.txt", safelist);
```